### PR TITLE
CoordinatesPicker fix for virtual attributes

### DIFF
--- a/CoordinatesPicker.php
+++ b/CoordinatesPicker.php
@@ -109,7 +109,7 @@ class CoordinatesPicker extends \yii\widgets\InputWidget
                 $this->attribute,
                 ['id'=> $inputId , 'name' => $inputName]
             );
-            $this->value = $this->model->attributes[$this->attribute];
+            $this->value = $this->model->{$this->attribute};
         }
         
        


### PR DESCRIPTION
I had some problems using ActiveRecord virtual attributes with CoordinatesPicker.
This pull request enables usage of this feature and allows make things like following:
```php
<?php
namespace common\models;

/**
 * Table schema attributes.
 * @property double $latitude
 * @property double $longitude
 *
 * Overloaded attribute.
 * @property string|null $coordinates
 */
class SomePlace extends \yii\db\ActiveRecord
{
    /**
     * @inheritdoc
     */
    public function rules()
    {
        return [
            ['coordinates', 'required'],
            ['coordinates', 'string']
        ];
    }

    /**
     * @return null|string
     */
    public function getCoordinates()
    {
        if (!$this->latitude || !$this->longitude) {
            return null;
        }
        return $this->latitude . ',' . $this->longitude;
    }

    /**
     * @param $coordinates
     */
    public function setCoordinates($coordinates)
    {
        $parts = explode(',', $coordinates);
        if (count($parts) === 2) {
            list($this->latitude, $this->longitude) = $parts;
        }
    }
}
```
This approach seems very efficient for me.
Much easier to integrate in comparison with this one https://github.com/pigochu/yii2-jquery-locationpicker/blob/master/doc/TWO-FIELDS-CONVERSION.md.
Thanks.